### PR TITLE
Implement server nodes with master and slave roles with configs from a file and flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # distributed-caching-and-loadbalancing-system
 A basic implementation and visualization of caching and load balancing system for distributed platform. It's a college project that implements basic implementation of data structures like LinkedLists, Hash Maps and Pointers.
+
+## Project Structure
+```
+distributed-caching-and-loadbalancing-system/
+|-- caching/
+|   |-- cache/
+|   |   |-- cache.go          // Cache implementation
+|   |   |-- cacher.go         // Cache interface
+|   |   |-- command.go        // Command processing logic
+|   |   |-- persist.go        // AOF persistence logic
+|   |-- replication.go       // Replication logic
+|-- server/
+|   |-- master.go            // Master server implementation
+|   |-- slave.go             // Slave server implementation
+|-- tmp/                     // Temporary files
+|-- config.yml               // Configuration file
+|-- main.go                  // Main application logic
+
+```

--- a/caching/cache/cache.go
+++ b/caching/cache/cache.go
@@ -29,27 +29,12 @@ type Node struct {
 }
 
 // NewCache creates a new Cache with an empty map and Queue.
-func NewCache(aofFilePath string) *Cache {
-	cache := &Cache{
+func NewCache() *Cache {
+	return &Cache{
 		CacheMap: make(map[string]*Node),
 		Queue:    NewQueue(),
 		mutex:    sync.Mutex{},
 	}
-
-	// Open or create AOF file
-	aofFile, err := openOrCreateAOFFile(aofFilePath)
-	if err != nil {
-		fmt.Println(RedColor+"Error opening AOF file:", err, ResetColor)
-		return nil
-	}
-
-	cache.aofFile = aofFile
-
-	// Replay AOF file
-	cache.replayingAOF = true
-	cache.ReplayAOF(aofFilePath)
-	cache.replayingAOF = false
-	return cache
 }
 
 // NewQueue creates a new Queue with empty head and tail.

--- a/caching/cache/command.go
+++ b/caching/cache/command.go
@@ -33,7 +33,7 @@ const (
 // MessageSet represents a SET command message
 type MessageSet struct {
 	Key   string
-	Value string
+	Value []byte
 	TTL   time.Duration
 }
 
@@ -43,9 +43,8 @@ type MessageGet struct {
 }
 
 func HandleCli() {
-	aofFilePathPtr := "tmp/aof.log"
 	// Create a new cache
-	cacheInstance := NewCache(aofFilePathPtr)
+	cacheInstance := NewCache()
 	defer cacheInstance.CloseAOF()
 
 	scanner := bufio.NewScanner(os.Stdin)
@@ -99,7 +98,7 @@ func handleSetCommand(c *Cache, args []string) {
 	}
 
 	key := args[0]
-	value := args[1]
+	value := []byte(args[1])
 	ttl, err := strconv.Atoi(args[2])
 	if err != nil {
 		fmt.Println(RedColor + "Error: Time to Live (TTL) must be a numeric value." + ResetColor)
@@ -161,7 +160,7 @@ func displayCommandGuide() {
 	fmt.Println()
 }
 
-func setCache(c *Cache, key string, value string, duration time.Duration) {
+func setCache(c *Cache, key string, value []byte, duration time.Duration) {
 	if key == "" || duration == 0 {
 		fmt.Println(RedColor + "Error: Key, value, and duration are required for 'SET' command." + ResetColor)
 		os.Exit(1)

--- a/caching/replication.go
+++ b/caching/replication.go
@@ -1,0 +1,5 @@
+package caching
+
+func replicateToFollowers() {
+
+}

--- a/caching/server/config.go
+++ b/caching/server/config.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"gopkg.in/yaml.v2"
+	"os"
+)
+
+type Config struct {
+	Cache struct {
+		Master struct {
+			Address string `yaml:"address"`
+			Port    string `yaml:"port"`
+		} `yaml:"master"`
+		AofFileUrl string `yaml:"aof"`
+	} `yaml:"cache"`
+}
+
+func readMasterNodeConfigs(configFileName string) (string, string, error) {
+	yamlFile, err := os.ReadFile(configFileName)
+	if err != nil {
+		return "", "", err
+	}
+
+	var config Config
+	err = yaml.Unmarshal(yamlFile, &config)
+	if err != nil {
+		return "", "", err
+	}
+
+	return config.Cache.Master.Address, config.Cache.Master.Port, nil
+}
+
+func getAofFileLocation(configFileName string) (string, error) {
+	yamlFile, err := os.ReadFile(configFileName)
+	if err != nil {
+		return "", err
+	}
+
+	var config Config
+	err = yaml.Unmarshal(yamlFile, &config)
+	if err != nil {
+		return "", err
+	}
+
+	return config.Cache.AofFileUrl, nil
+}

--- a/caching/server/master.go
+++ b/caching/server/master.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"distributed-caching-and-loadbalancing-system/caching/cache"
+	"encoding/json"
+	"fmt"
+	"net"
+)
+
+func RunAsMaster(port string) {
+	ln, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	defer ln.Close()
+
+	fmt.Println("Running as master on port", port)
+	aofUrl, _ := getAofFileLocation("config.yaml")
+	cacheInstance := cache.NewCache()
+	cacheInstance.ReplayAOF(aofUrl)
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			fmt.Println("Error accepting connection:", err)
+			continue
+		}
+
+		go handleSlaveConnection(conn)
+	}
+}
+
+func handleSlaveConnection(conn net.Conn) {
+	defer conn.Close()
+
+	// Read slave information from the connection
+	slaveInfo := NodeInfo{}
+	decoder := json.NewDecoder(conn)
+	err := decoder.Decode(&slaveInfo)
+	if err != nil {
+		fmt.Println("Error reading slave information:", err)
+		return
+	}
+
+	fmt.Println("Slave connected:", slaveInfo)
+}

--- a/caching/server/server-node.go
+++ b/caching/server/server-node.go
@@ -1,0 +1,13 @@
+package server
+
+import "strconv"
+
+type NodeInfo struct {
+	NodeId     int    `json:"nodeId"`
+	NodeIpAddr string `json:"nodeIpAddr"`
+	Port       string `json:"port"`
+}
+
+func (node NodeInfo) String() string {
+	return "NodeInfo:{ nodeId:" + strconv.Itoa(node.NodeId) + ", nodeIpAddr:" + node.NodeIpAddr + ", port:" + node.Port + " }"
+}

--- a/caching/server/slave.go
+++ b/caching/server/slave.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"distributed-caching-and-loadbalancing-system/caching/cache"
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+)
+
+func RunAsSlave(port string) {
+	// Read configuration file
+	masterAddr, masterPort, err := readMasterNodeConfigs("config.yml")
+	if err != nil {
+		fmt.Println("Error reading config file:", err)
+		return
+	}
+
+	conn, err := net.Dial("tcp", masterAddr+":"+masterPort)
+	if err != nil {
+		fmt.Println("Error connecting to master:", err)
+		return
+	}
+	defer conn.Close()
+
+	fmt.Println("Connected to master at", masterAddr+":"+masterPort)
+
+	// Prepare slave information
+	slaveInfo := NodeInfo{
+		NodeId:     generateUniqueId(),
+		NodeIpAddr: getOutboundIP(),
+		Port:       port,
+	}
+
+	// Send JSON-encoded slave information to master
+	encoder := json.NewEncoder(conn)
+	err = encoder.Encode(slaveInfo)
+	if err != nil {
+		fmt.Println("Error sending slave information to master:", err)
+		return
+	}
+
+	cache.HandleCli()
+}
+
+func generateUniqueId() int {
+	// You can implement your unique ID generation logic here
+	// For simplicity, let's use the current timestamp as the ID
+	return int(time.Now().Unix())
+}
+
+func getOutboundIP() string {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		fmt.Println("Error getting outbound IP:", err)
+		return ""
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	return localAddr.IP.String()
+}

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,9 @@
 cache:
-  server:
-    noOfReplicas: 4
-    maxCacheSize: 2048
-    defaultTtl: 86400
+  master:
+    address: 127.0.0.1
+    port: 8080
+
+  aof: tmp/aof.log
+  noOfReplicas: 4
+  maxCacheSize: 2048
+  defaultTtl: 86400

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module distributed-caching-and-loadbalancing-system
 
 go 1.21
+
+require gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"distributed-caching-and-loadbalancing-system/caching/cache"
+	"distributed-caching-and-loadbalancing-system/caching/server"
+	"flag"
 	"fmt"
 )
 
@@ -9,7 +10,17 @@ func main() {
 	fmt.Println("\n````````````````````````````````````````````````````````````````")
 
 	// Handle CLI operations
-	cache.HandleCli()
+	//cache.HandleCli()
+
+	makeMaster := flag.Bool("master", false, "Run as master")
+	port := flag.String("port", "8080", "Port to run on")
+	flag.Parse()
+
+	if *makeMaster {
+		server.RunAsMaster(*port)
+	} else {
+		server.RunAsSlave(*port)
+	}
 
 	fmt.Println("````````````````````````````````````````````````````````````````")
 }

--- a/tmp/aof.log
+++ b/tmp/aof.log
@@ -1,4 +1,3 @@
-SET key1 value1 100000
-SET key2 value2 20000
-DELETE key2
-DELETE key1
+SET key1 value1 1024000
+SET key2 value2 100000
+SET key3 value3 10245000


### PR DESCRIPTION
Implementation for #7 and #8.


From now master instance can be started with a flag `-master` or with value `true`. By default master will take port 8080 but for changing port a flag `-port` can be kept with values.

For slaves a `port` is required flag to be mentioned which is mandatory for the slave to be listening on that specific port. And for the slave, the master confgurations are to be kept on `config.yml` file. 